### PR TITLE
Improve public API on extensions.

### DIFF
--- a/Differific.podspec
+++ b/Differific.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Differific"
   s.summary          = "A fast and convenient diffing framework"
-  s.version          = "0.1.0"
+  s.version          = "0.1.1"
   s.homepage         = "https://github.com/zenangst/Differific"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Source/iOS+tvOS/UICollectionView+Extensions.swift
+++ b/Source/iOS+tvOS/UICollectionView+Extensions.swift
@@ -7,6 +7,7 @@ extension UICollectionView {
   ///   - changes: A generic collection of changes.
   ///   - section: The section that will be updated.
   ///   - before: A closure that will be invoked before the updates.
+  ///             This is where you should update your data source.
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   section: Int = 0,

--- a/Source/iOS+tvOS/UICollectionView+Extensions.swift
+++ b/Source/iOS+tvOS/UICollectionView+Extensions.swift
@@ -10,17 +10,20 @@ extension UICollectionView {
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   section: Int = 0,
-                                  before: ((UICollectionView) -> Void)? = nil,
+                                  before: (() -> Void)? = nil,
                                   completion: (() -> Void)? = nil) {
     guard !changes.isEmpty else {
       completion?()
       return
     }
 
+    setNeedsLayout()
+    layoutIfNeeded()
+
     let manager = IndexPathManager()
     let result = manager.process(changes, section: section)
 
-    before?(self)
+    before?()
 
     performBatchUpdates({
       insertItems(at: result.insert)

--- a/Source/iOS+tvOS/UITableView+Extensions.swift
+++ b/Source/iOS+tvOS/UITableView+Extensions.swift
@@ -8,6 +8,7 @@ public extension UITableView {
   ///   - animation: The animation that should be used when performing the update.
   ///   - section: The section that will be updated.
   ///   - before: A closure that will be invoked before the updates.
+  ///             This is where you should update your data source.
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   animation: UITableViewRowAnimation = .automatic,

--- a/Source/iOS+tvOS/UITableView+Extensions.swift
+++ b/Source/iOS+tvOS/UITableView+Extensions.swift
@@ -12,17 +12,20 @@ public extension UITableView {
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   animation: UITableViewRowAnimation = .automatic,
                                   section: Int = 0,
-                                  before: ((UITableView) -> Void)? = nil,
+                                  before: (() -> Void)? = nil,
                                   completion: (() -> Void)? = nil) {
     guard !changes.isEmpty else {
       completion?()
       return
     }
 
+    setNeedsLayout()
+    layoutIfNeeded()
+
     let manager = IndexPathManager()
     let result = manager.process(changes, section: section)
 
-    before?(self)
+    before?()
 
     if #available(iOS 11, tvOS 11, *) {
       performBatchUpdates({

--- a/Source/macOS/NSCollectionView+Extensions.swift
+++ b/Source/macOS/NSCollectionView+Extensions.swift
@@ -10,7 +10,7 @@ public extension NSCollectionView {
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   section: Int = 0,
-                                  before: ((NSCollectionView) -> Void)? = nil,
+                                  before: (() -> Void)? = nil,
                                   completion: (() -> Void)? = nil) {
     guard !changes.isEmpty else {
       completion?()
@@ -20,7 +20,7 @@ public extension NSCollectionView {
     let manager = IndexPathManager()
     let result = manager.process(changes, section: section)
 
-    before?(self)
+    before?()
 
     performBatchUpdates({
       insertItems(at: Set(result.insert))

--- a/Source/macOS/NSCollectionView+Extensions.swift
+++ b/Source/macOS/NSCollectionView+Extensions.swift
@@ -7,6 +7,7 @@ public extension NSCollectionView {
   ///   - changes: A generic collection of changes.
   ///   - section: The section that will be updated.
   ///   - before: A closure that will be invoked before the updates.
+  ///             This is where you should update your data source.
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   section: Int = 0,

--- a/Source/macOS/NSTableView+Extensions.swift
+++ b/Source/macOS/NSTableView+Extensions.swift
@@ -12,7 +12,7 @@ public extension NSTableView {
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   animation: NSTableView.AnimationOptions,
                                   section: Int = 0,
-                                  before: ((NSTableView) -> Void)? = nil,
+                                  before: (() -> Void)? = nil,
                                   completion: (() -> Void)? = nil) {
     guard !changes.isEmpty else {
       completion?()
@@ -25,7 +25,7 @@ public extension NSTableView {
     let deletions = IndexSet(result.deletions.compactMap { $0.item })
     let updates = IndexSet(result.updates.compactMap { $0.item })
 
-    before?(self)
+    before?()
 
     beginUpdates()
     removeRows(at: deletions, withAnimation: animation)

--- a/Source/macOS/NSTableView+Extensions.swift
+++ b/Source/macOS/NSTableView+Extensions.swift
@@ -8,6 +8,7 @@ public extension NSTableView {
   ///   - animation: The animation that should be used when performing the update.
   ///   - section: The section that will be updated.
   ///   - before: A closure that will be invoked before the updates.
+  ///             This is where you should update your data source.
   ///   - completion: A closure that is invoked after the updates are done.
   public func reload<T: Hashable>(with changes: [Change<T>],
                                   animation: NSTableView.AnimationOptions,

--- a/Tests/iOS+tvOS/UICollectionViewExtensionsTests.swift
+++ b/Tests/iOS+tvOS/UICollectionViewExtensionsTests.swift
@@ -63,8 +63,8 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    dataSource.models = new
     collectionView.reload(with: changes, before: {
+      dataSource.models = new
       ranBefore = true
     }) {
       ranCompletion = true
@@ -91,8 +91,8 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    dataSource.models = new
     collectionView.reload(with: changes, before: {
+      dataSource.models = new
       ranBefore = true
     }) {
       ranCompletion = true
@@ -119,8 +119,8 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    dataSource.models = new
     collectionView.reload(with: changes, before: {
+      dataSource.models = new
       ranBefore = true
     }) {
       ranCompletion = true

--- a/Tests/iOS+tvOS/UICollectionViewExtensionsTests.swift
+++ b/Tests/iOS+tvOS/UICollectionViewExtensionsTests.swift
@@ -27,8 +27,6 @@ class UICollectionViewExtensionsTests: XCTestCase {
                                           collectionViewLayout: layout)
     collectionView.dataSource = dataSource
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
-    collectionView.setNeedsLayout()
-    collectionView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = ["Foo", "Bar", "Baz"]
@@ -37,8 +35,8 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
+      dataSource.models = new
       ranBefore = true
     }) {
       ranCompletion = true
@@ -56,8 +54,6 @@ class UICollectionViewExtensionsTests: XCTestCase {
                                           collectionViewLayout: layout)
     collectionView.dataSource = dataSource
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
-    collectionView.setNeedsLayout()
-    collectionView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = ["Baz", "Bar", "Foo"]
@@ -68,7 +64,7 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true
@@ -86,8 +82,6 @@ class UICollectionViewExtensionsTests: XCTestCase {
                                           collectionViewLayout: layout)
     collectionView.dataSource = dataSource
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
-    collectionView.setNeedsLayout()
-    collectionView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = [String]()
@@ -98,7 +92,7 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true
@@ -116,8 +110,6 @@ class UICollectionViewExtensionsTests: XCTestCase {
                                           collectionViewLayout: layout)
     collectionView.dataSource = dataSource
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
-    collectionView.setNeedsLayout()
-    collectionView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = ["Foo", "Bar", "Baz"]
@@ -128,7 +120,7 @@ class UICollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true

--- a/Tests/iOS+tvOS/UITableViewExtensionsTests.swift
+++ b/Tests/iOS+tvOS/UITableViewExtensionsTests.swift
@@ -25,8 +25,6 @@ class UITableViewExtensionsTests: XCTestCase {
     tableView.dataSource = dataSource
     tableView.register(UITableViewCell.self,
                        forCellReuseIdentifier: "cell")
-    tableView.setNeedsLayout()
-    tableView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = ["Foo", "Bar", "Baz"]
@@ -36,7 +34,7 @@ class UITableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, before: { _ in
+    tableView.reload(with: changes, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -53,8 +51,6 @@ class UITableViewExtensionsTests: XCTestCase {
     tableView.dataSource = dataSource
     tableView.register(UITableViewCell.self,
                        forCellReuseIdentifier: "cell")
-    tableView.setNeedsLayout()
-    tableView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = ["Baz", "Bar", "Foo"]
@@ -64,7 +60,7 @@ class UITableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, before: { _ in
+    tableView.reload(with: changes, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -81,8 +77,6 @@ class UITableViewExtensionsTests: XCTestCase {
     tableView.dataSource = dataSource
     tableView.register(UITableViewCell.self,
                        forCellReuseIdentifier: "cell")
-    tableView.setNeedsLayout()
-    tableView.layoutIfNeeded()
 
     let old = dataSource.models
     let new = [String]()
@@ -92,7 +86,7 @@ class UITableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, before: { _ in
+    tableView.reload(with: changes, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -118,7 +112,7 @@ class UITableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, before: { _ in
+    tableView.reload(with: changes, before: {
       dataSource.models = new
       ranBefore = true
     }) {

--- a/Tests/macOS/NSCollectionViewExtensionTests.swift
+++ b/Tests/macOS/NSCollectionViewExtensionTests.swift
@@ -37,7 +37,7 @@ class NSCollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true
@@ -65,7 +65,7 @@ class NSCollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true
@@ -93,7 +93,7 @@ class NSCollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true
@@ -121,7 +121,7 @@ class NSCollectionViewExtensionsTests: XCTestCase {
     var ranCompletion: Bool = false
 
     dataSource.models = new
-    collectionView.reload(with: changes, before: { _ in
+    collectionView.reload(with: changes, before: {
       ranBefore = true
     }) {
       ranCompletion = true

--- a/Tests/macOS/NSTableViewExtensionsTests.swift
+++ b/Tests/macOS/NSTableViewExtensionsTests.swift
@@ -27,7 +27,7 @@ class NSTableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, animation: .effectFade, before: { _ in
+    tableView.reload(with: changes, animation: .effectFade, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -51,7 +51,7 @@ class NSTableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, animation: .effectFade, before: { _ in
+    tableView.reload(with: changes, animation: .effectFade, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -75,7 +75,7 @@ class NSTableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, animation: .effectFade, before: { _ in
+    tableView.reload(with: changes, animation: .effectFade, before: {
       dataSource.models = new
       ranBefore = true
     }) {
@@ -99,7 +99,7 @@ class NSTableViewExtensionsTests: XCTestCase {
     var ranBefore: Bool = false
     var ranCompletion: Bool = false
 
-    tableView.reload(with: changes, animation: .effectFade, before: { _ in
+    tableView.reload(with: changes, animation: .effectFade, before: {
       dataSource.models = new
       ranBefore = true
     }) {


### PR DESCRIPTION
There is really no need to pass the UI element into the before closure as it is available at the call-site.
So instead of always writing `_ in`, the element is no longer passed into the closure.

- Remove UI element from before closure.
- Call setNeedsLayout() and layoutIfNeeded() in extension methods.