### PR TITLE
Fix crash with only one new match

### DIFF
--- a/Differific.podspec
+++ b/Differific.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Differific"
   s.summary          = "A fast and convenient diffing framework"
-  s.version          = "0.5.1"
+  s.version          = "0.5.2"
   s.homepage         = "https://github.com/zenangst/Differific"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -70,27 +70,30 @@ class Algorithm {
 
     // 4th Pass
     offset = 1
-    repeat {
-      if case let .indexInOther(otherIndex) = newArray[offset], otherIndex + 1 < oldArray.count,
-        case let .tableEntry(newEntry) = newArray[offset + 1],
-        case let .tableEntry(oldEntry) = oldArray[otherIndex + 1], newEntry === oldEntry {
-        newArray[offset + 1] = .indexInOther(otherIndex + 1)
-        oldArray[otherIndex + 1] = .indexInOther(offset + 1)
-      }
-      offset += 1
-    } while offset < newArray.count - 1
+    if new.count > offset {
+      repeat {
+        if case let .indexInOther(otherIndex) = newArray[offset], otherIndex + 1 < oldArray.count,
+          case let .tableEntry(newEntry) = newArray[offset + 1],
+          case let .tableEntry(oldEntry) = oldArray[otherIndex + 1], newEntry === oldEntry {
+          newArray[offset + 1] = .indexInOther(otherIndex + 1)
+          oldArray[otherIndex + 1] = .indexInOther(offset + 1)
+        }
+        offset += 1
+      } while offset < newArray.count - 1
 
-    // 5th Pass
-    offset = newArray.count - 1
-    repeat {
-      if case let .indexInOther(otherIndex) = newArray[offset], otherIndex - 1 >= 0,
-        case let .tableEntry(newEntry) = newArray[offset - 1],
-        case let .tableEntry(oldEntry) = oldArray[otherIndex - 1], newEntry === oldEntry {
-        newArray[offset - 1] = .indexInOther(otherIndex - 1)
-        oldArray[otherIndex - 1] = .indexInOther(offset - 1)
-      }
-      offset -= 1
-    } while offset > 0
+
+      // 5th Pass
+      offset = newArray.count - 1
+      repeat {
+        if case let .indexInOther(otherIndex) = newArray[offset], otherIndex - 1 >= 0,
+          case let .tableEntry(newEntry) = newArray[offset - 1],
+          case let .tableEntry(oldEntry) = oldArray[otherIndex - 1], newEntry === oldEntry {
+          newArray[offset - 1] = .indexInOther(otherIndex - 1)
+          oldArray[otherIndex - 1] = .indexInOther(offset - 1)
+        }
+        offset -= 1
+      } while offset > 0
+    }
 
     // Handle deleted objects
     offset = 0

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -70,7 +70,8 @@ class Algorithm {
 
     // 4th Pass
     offset = 1
-    if new.count > offset {
+
+    if newArray.count > offset {
       repeat {
         if case let .indexInOther(otherIndex) = newArray[offset], otherIndex + 1 < oldArray.count,
           case let .tableEntry(newEntry) = newArray[offset + 1],
@@ -80,10 +81,12 @@ class Algorithm {
         }
         offset += 1
       } while offset < newArray.count - 1
+    }
+    
+    // 5th Pass
+    offset = newArray.count - 1
 
-
-      // 5th Pass
-      offset = newArray.count - 1
+    if offset > newArray.count {
       repeat {
         if case let .indexInOther(otherIndex) = newArray[offset], otherIndex - 1 >= 0,
           case let .tableEntry(newEntry) = newArray[offset - 1],
@@ -94,6 +97,7 @@ class Algorithm {
         offset -= 1
       } while offset > 0
     }
+
 
     // Handle deleted objects
     offset = 0


### PR DESCRIPTION
Fix crash when trying to diff two collection where the new one only contains one item.
When this happens the algorithm went out of bounds as it moves the offset around.