### PR TITLE
Improve diff performance

### DIFF
--- a/Example/DifferificDemo/DifferificDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/DifferificDemo/DifferificDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -66,7 +66,8 @@ class Algorithm {
     // 3rd Pass
     offset = 0
     for element in newArray[0...].lazy {
-      if case let .tableEntry(entry) = element, (entry.appearsInBoth && !entry.indexesInOld.isEmpty) {
+      if case let .tableEntry(entry) = element,
+        (entry.appearsInBoth && !entry.indexesInOld.isEmpty) {
         let oldIndex = entry.indexesInOld.removeFirst()
         newArray[offset] = .indexInOther(oldIndex)
         oldArray[oldIndex] = .indexInOther(offset)

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -48,8 +48,6 @@ class Algorithm {
 
     // 2 Pass
     for element in old[0...].lazy {
-      defer { offset += 1 }
-
       let entry: TableEntry
       if let tableEntry = table[element.hashValue] {
         entry = tableEntry
@@ -61,17 +59,18 @@ class Algorithm {
       entry.oldCounter = entry.oldCounter.increment()
       entry.indexesInOld.append(offset)
       oldArray.append(.tableEntry(entry))
+      offset += 1
     }
 
     // 3rd Pass
     offset = 0
     for element in newArray[0...].lazy {
-      defer { offset += 1 }
       if case let .tableEntry(entry) = element, (entry.appearsInBoth && !entry.indexesInOld.isEmpty) {
         let oldIndex = entry.indexesInOld.removeFirst()
         newArray[offset] = .indexInOther(oldIndex)
         oldArray[oldIndex] = .indexInOther(offset)
       }
+      offset += 1
     }
 
     // 4th Pass
@@ -104,11 +103,9 @@ class Algorithm {
       } while offset > 0
     }
 
-
     // Handle deleted objects
     offset = 0
     for element in oldArray[0...].lazy {
-      defer { offset += 1 }
       deleteOffsets[offset] = runningOffset
       if case let .tableEntry(entry) = element {
         changes.append(Change(.delete,
@@ -116,12 +113,12 @@ class Algorithm {
                               index: offset))
         runningOffset += 1
       }
+      offset += 1
     }
 
     // Handle insert, updates and move.
     offset = 0
     for element in newArray[0...].lazy {
-      defer { offset += 1 }
       switch element {
       case .tableEntry(_):
         changes.append(Change(.insert,
@@ -145,6 +142,7 @@ class Algorithm {
           }
         }
       }
+      offset += 1
     }
 
     return changes

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -4,6 +4,7 @@ class Algorithm {
   public static func diff<T: Hashable>(old: [T], new: [T]) -> [Change<T>] {
     if new.isEmpty {
       var changes = [Change<T>]()
+      changes.reserveCapacity(old.count)
       for (offset, element) in old.enumerated() {
         changes.append(Change(.delete,
                               item: element,
@@ -12,6 +13,7 @@ class Algorithm {
       return changes
     } else if old.isEmpty {
       var changes = [Change<T>]()
+      changes.reserveCapacity(new.count)
       for (offset, element) in new.enumerated() {
         changes.append(Change(.insert,
                               item: element,
@@ -25,6 +27,10 @@ class Algorithm {
     var deleteOffsets = Array(repeating: 0, count: old.count)
     var changes = [Change<T>]()
     var (runningDeleteOffset, runningOffset, offset) = (0, 0, 0)
+    table.reserveCapacity(new.count > old.count ? new.count : old.count)
+    changes.reserveCapacity(newArray.count + oldArray.count)
+    newArray.reserveCapacity(new.count)
+    oldArray.reserveCapacity(old.count)
 
     // 1 Pass
     for element in new[0...].lazy {

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -26,7 +26,8 @@ class Algorithm {
     var (oldArray, newArray) = ([ArrayEntry](), [ArrayEntry]())
     var deleteOffsets = Array(repeating: 0, count: old.count)
     var changes = [Change<T>]()
-    var (runningDeleteOffset, runningOffset, offset) = (0, 0, 0)
+    var (runningOffset, offset) = (0, 0)
+
     table.reserveCapacity(new.count > old.count ? new.count : old.count)
     changes.reserveCapacity(newArray.count + oldArray.count)
     newArray.reserveCapacity(new.count)

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -88,7 +88,7 @@ class Algorithm {
         offset += 1
       } while offset < newArray.count - 1
     }
-    
+
     // 5th Pass
     offset = newArray.count - 1
 

--- a/Source/Shared/Algorithm.swift
+++ b/Source/Shared/Algorithm.swift
@@ -108,7 +108,7 @@ class Algorithm {
     offset = 0
     for element in oldArray[0...].lazy {
       deleteOffsets[offset] = runningOffset
-      if case let .tableEntry(entry) = element {
+      if case .tableEntry(_) = element {
         changes.append(Change(.delete,
                               item: old[offset],
                               index: offset))

--- a/Source/Shared/ArrayEntry.swift
+++ b/Source/Shared/ArrayEntry.swift
@@ -1,17 +1,11 @@
 import Foundation
 
-enum ArrayEntry: Equatable {
-  case tableEntry(TableEntry)
-  case indexInOther(Int)
+struct ArrayEntry: Equatable {
+  let tableEntry: TableEntry
+  var indexInOther: Int
 
-  public static func == (lhs: ArrayEntry, rhs: ArrayEntry) -> Bool {
-    switch (lhs, rhs) {
-    case (.tableEntry(let l), .tableEntry(let r)):
-      return l == r
-    case (.indexInOther(let l), .indexInOther(let r)):
-      return l == r
-    default:
-      return false
-    }
+  init(tableEntry: TableEntry, indexInOther: Int = -1) {
+    self.tableEntry = tableEntry
+    self.indexInOther = indexInOther
   }
 }

--- a/Source/Shared/TableEntry.swift
+++ b/Source/Shared/TableEntry.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 class TableEntry: Equatable {
-  var oldCounter: Counter = .zero
-  var newCounter: Counter = .zero
+  var oldCounter: Int = 0
+  var newCounter: Int = 0
   var indexesInOld: [Int] = []
   var appearsInBoth: Bool {
-    return oldCounter != .zero && newCounter != .zero
+    return oldCounter > 0 && newCounter > 0
   }
 
   static func == (lhs: TableEntry, rhs: TableEntry) -> Bool {

--- a/Tests/Shared/DiffManagerTests.swift
+++ b/Tests/Shared/DiffManagerTests.swift
@@ -147,4 +147,25 @@ class DiffManagerTests: XCTestCase {
 
     XCTAssertEqual(result.count, 5)
   }
+
+  func testPerformance() {
+    let diffManager = DiffManager()
+    var old = [Int]()
+    var new = [Int]()
+    let amount = 1_000_000
+
+    new.reserveCapacity(amount)
+    old.reserveCapacity(amount)
+
+    for x in 0..<amount {
+      old.append(x)
+      new.append(x)
+    }
+
+    let startTime = CACurrentMediaTime()
+
+    _ = diffManager.diff(old, new.reversed())
+
+    NSLog("🏎 Total Runtime: \(CACurrentMediaTime() - startTime)")
+  }
 }


### PR DESCRIPTION
This PR improves diff performance by using reserving capacity of the arrays before diffing.
It also simplifies the implementation by removing enum and uses concrete value types instead, this should not affect performance but in my own personal opinion, it is easier to reason about as opposed to looking "fancy".

The use of `defer` has also been removed to make the code more linear.