### PR TITLE
Improve macOS extensions setting needsLayout

### DIFF
--- a/Differific.podspec
+++ b/Differific.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Differific"
   s.summary          = "A fast and convenient diffing framework"
-  s.version          = "0.7.1"
+  s.version          = "0.7.2"
   s.homepage         = "https://github.com/zenangst/Differific"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Source/macOS/NSCollectionView+Extensions.swift
+++ b/Source/macOS/NSCollectionView+Extensions.swift
@@ -33,6 +33,8 @@ public extension NSCollectionView {
       }
     }, completionHandler: nil)
 
+    needsLayout = true
+
     completion?()
   }
 

--- a/Source/macOS/NSTableView+Extensions.swift
+++ b/Source/macOS/NSTableView+Extensions.swift
@@ -41,6 +41,8 @@ public extension NSTableView {
 
     animator().endUpdates()
 
+    needsLayout = true
+
     completion?()
   }
 


### PR DESCRIPTION
By setting `needsLayout` to `true`. The resizing of the views are more predictable.